### PR TITLE
Add fallback route named 'fallback'

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -69,4 +69,4 @@ Route::put('/tasks/{task}/complete', function (Task $task) {
 
 Route::fallback(function () {
     return redirect()->route('tasks.index');
-});
+})->name('fallback');


### PR DESCRIPTION
Implement a fallback route in Laravel that redirects unmatched requests to the 'tasks.index' route and assign it the name 'fallback' for easier reference and maintenance.