### PR TITLE
Extract task status field into separate table

### DIFF
--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -12,4 +12,9 @@ class Task extends Model
     // public $timestamps = false;
 
     protected $fillable = ['title', 'description'];
+
+    public function status()
+    {
+        return $this->hasOne(TaskStatus::class);
+    }
 }

--- a/app/Models/TaskStatus.php
+++ b/app/Models/TaskStatus.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Model;
+
+class TaskStatus extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['status'];
+
+    public function task(): BelongsTo
+    {
+        return $this->belongsTo(Task::class);
+    }
+}

--- a/database/migrations/2024_12_22_085806_create_task_statuses_table.php
+++ b/database/migrations/2024_12_22_085806_create_task_statuses_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('task_statuses', function (Blueprint $table) {
+            $table->unsignedBigInteger('task_id');
+            $table->boolean('status')->default(false);
+            $table->timestamps();
+
+            $table->foreign('task_id')->references('id')->on('tasks')->onUpdate('cascade')->onDelete('cascade');
+            $table->primary('task_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('task_statuses');
+    }
+};

--- a/database/migrations/2024_12_22_114319_remove_completed_from_tasks.php
+++ b/database/migrations/2024_12_22_114319_remove_completed_from_tasks.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->dropColumn('completed');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->string('completed')->nullable();
+        });
+    }
+};

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -26,7 +26,7 @@
                 <form method="POST" action="{{ route('tasks.complete', $task) }}">
                     @csrf
                     @method('PUT')
-                    <button class="btn btn-outline-dark" type="submit">{{ $task->completed ? 'Completed' : 'Not completed' }}</button>
+                    <button class="btn btn-outline-dark" type="submit">{{ $task->status->status ? 'Completed' : 'Not completed' }}</button>
                 </form>
             </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Requests\TaskRequest;
 use Illuminate\Support\Facades\Route;
 use App\Models\Task;
+use App\Models\TaskStatus;
 use Illuminate\Http\Request;
 
 /*
@@ -44,6 +45,7 @@ Route::get('/tasks/{task}', function (Task $task) {
 
 Route::post('tasks', function (TaskRequest $request) {
     $task = Task::create($request->validated());
+    $task->status()->create();
 
     return redirect()->route('tasks.show', $task)->with('success', 'Task created');
 })->name('tasks.store');
@@ -61,8 +63,10 @@ Route::delete('/tasks/{task}', function (Task $task) {
 })->name('tasks.delete');
 
 Route::put('/tasks/{task}/complete', function (Task $task) {
-    $task->completed = !$task->completed;
     $task->save();
+
+    $task->status->status = !$task->status->status;
+    $task->status()->update(['status' => $task->status->status]);
 
     return redirect()->back()->with('success', $task->completed ? 'Task completed' : 'Task not completed');
 })->name('tasks.complete');


### PR DESCRIPTION
Refactor database schema by moving the task status field from the existing tasks table into a dedicated task_statuses table to improve normalization and maintainability.