### PR TITLE
Fix task status factory to use one-to-one relationship

### DIFF
--- a/database/factories/TaskStatusFactory.php
+++ b/database/factories/TaskStatusFactory.php
@@ -10,8 +10,6 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 class TaskStatusFactory extends Factory
 {
 
-    public $sequenceNumber = 0;
-
     /**
      * Define the model's default state.
      *
@@ -21,13 +19,6 @@ class TaskStatusFactory extends Factory
     {
         return [
             'status' => fake()->boolean,
-            'task_id' => $this->generateSequenceNumber()
         ];
-    }
-
-    function generateSequenceNumber()
-    {
-        ++$this->sequenceNumber;
-        return $this->sequenceNumber;
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,8 @@
 namespace Database\Seeders;
 
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+
+use App\Models\TaskStatus;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -13,8 +15,9 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         // \App\Models\User::factory(10)->create();
-        \App\Models\Task::factory(50)->create();
-        \App\Models\TaskStatus::factory(50)->create();
+        \App\Models\Task::factory(50)->create()->each(function($task) {
+            $task->status()->save(TaskStatus::factory()->make());
+        });
 
         // \App\Models\User::factory()->create([
         //     'name' => 'Test User',


### PR DESCRIPTION
Modify the task status factory to establish a one-to-one relationship between Task model and TaskStatus model, ensuring proper association and data integrity during seeding process.