### PR TITLE
Remove unused imports from web.php

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -3,8 +3,6 @@
 use App\Http\Requests\TaskRequest;
 use Illuminate\Support\Facades\Route;
 use App\Models\Task;
-use App\Models\TaskStatus;
-use Illuminate\Http\Request;
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
Clean up web.php routes file by removing unnecessary import statements for App\Models\TaskStatus and Illuminate\Http\Request, improving code readability and reducing clutter.